### PR TITLE
Remove `plugin.name`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ function setEnvVars(key, val) {
 }
 
 module.exports = {
-  name: 'netlify-plugin-env-variables',
   onPreBuild: async({
     constants,
     inputs


### PR DESCRIPTION
This removes the `name` property on plugins, because it has been moved to the `manifest.yml` instead.